### PR TITLE
Feldera OpenTelemetry demo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,24 +128,29 @@ generate-kubernetes-manifests:
 .PHONY: start
 start:
 	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) up --force-recreate --remove-orphans --detach
+	# Install Feldera Python SDK.
+	python3 -m pip install feldera
+	# Python script to start the Feldera pipeline.
+	python3 start_feldera_pipeline.py
 	@echo ""
-	@echo "OpenTelemetry Demo is running."
+	@echo "OpenTelemetry Feldera Demo is running."
+	@echo "Go to http://localhost:28080 for the Feldera UI."
 	@echo "Go to http://localhost:8080 for the demo UI."
 	@echo "Go to http://localhost:8080/jaeger/ui for the Jaeger UI."
 	@echo "Go to http://localhost:8080/grafana/ for the Grafana UI."
 	@echo "Go to http://localhost:8080/loadgen/ for the Load Generator UI."
 	@echo "Go to http://localhost:8080/feature/ to to change feature flags."
 
-.PHONY: start-minimal
-start-minimal:
-	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) -f docker-compose.minimal.yml up --force-recreate --remove-orphans --detach
-	@echo ""
-	@echo "OpenTelemetry Demo in minimal mode is running."
-	@echo "Go to http://localhost:8080 for the demo UI."
-	@echo "Go to http://localhost:8080/jaeger/ui for the Jaeger UI."
-	@echo "Go to http://localhost:8080/grafana/ for the Grafana UI."
-	@echo "Go to http://localhost:8080/loadgen/ for the Load Generator UI."
-	@echo "Go to https://opentelemetry.io/docs/demo/feature-flags/ to learn how to change feature flags."
+#.PHONY: start-minimal
+#start-minimal:
+#	$(DOCKER_COMPOSE_CMD) $(DOCKER_COMPOSE_ENV) -f docker-compose.minimal.yml up --force-recreate --remove-orphans --detach
+#	@echo ""
+#	@echo "OpenTelemetry Demo in minimal mode is running."
+#	@echo "Go to http://localhost:8080 for the demo UI."
+#	@echo "Go to http://localhost:8080/jaeger/ui for the Jaeger UI."
+#	@echo "Go to http://localhost:8080/grafana/ for the Grafana UI."
+#	@echo "Go to http://localhost:8080/loadgen/ for the Load Generator UI."
+#	@echo "Go to https://opentelemetry.io/docs/demo/feature-flags/ to learn how to change feature flags."
 
 .PHONY: stop
 stop:

--- a/README.md
+++ b/README.md
@@ -1,140 +1,62 @@
-<!-- markdownlint-disable-next-line -->
-# <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OTel logo" width="45"> OpenTelemetry Demo
+# Feldera OpenTelemetry Demo
 
-[![Slack](https://img.shields.io/badge/slack-@cncf/otel/demo-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03B4CWV4DA)
-[![Version](https://img.shields.io/github/v/release/open-telemetry/opentelemetry-demo?color=blueviolet)](https://github.com/open-telemetry/opentelemetry-demo/releases)
-[![Commits](https://img.shields.io/github/commits-since/open-telemetry/opentelemetry-demo/latest?color=ff69b4&include_prereleases)](https://github.com/open-telemetry/opentelemetry-demo/graphs/commit-activity)
-[![Downloads](https://img.shields.io/docker/pulls/otel/demo)](https://hub.docker.com/r/otel/demo)
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?color=red)](https://github.com/open-telemetry/opentelemetry-demo/blob/main/LICENSE)
-[![Integration Tests](https://github.com/open-telemetry/opentelemetry-demo/actions/workflows/run-integration-tests.yml/badge.svg)](https://github.com/open-telemetry/opentelemetry-demo/actions/workflows/run-integration-tests.yml)
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opentelemetry-demo)](https://artifacthub.io/packages/helm/opentelemetry-helm/opentelemetry-demo)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9247/badge)](https://www.bestpractices.dev/en/projects/9247)
+This is a fork of the [OpenTelemetry demo](https://github.com/open-telemetry/opentelemetry-demo)
+that demonstrates the use of Feldera to analyze OpenTelemetry data in real-time
+using SQL.
 
-## Welcome to the OpenTelemetry Astronomy Shop Demo
+The demo currently implements the following analysis:
+* Parse OTel trace stream.
+* Flatten ResourceSpans data into individual spans (in SQL).
+* Global aggregation: compute totals and average runtimes per scope
+  for the entire event history.
+* Time-based aggregation: compute the same aggregates per 1-minute
+  tumbling window.
 
-This repository contains the OpenTelemetry Astronomy Shop, a microservice-based
-distributed system intended to illustrate the implementation of OpenTelemetry in
-a near real-world environment.
+## Running the demo
 
-Our goals are threefold:
+Start the demo using
 
-- Provide a realistic example of a distributed system that can be used to
-  demonstrate OpenTelemetry instrumentation and observability.
-- Build a base for vendors, tooling authors, and others to extend and
-  demonstrate their OpenTelemetry integrations.
-- Create a living example for OpenTelemetry contributors to use for testing new
-  versions of the API, SDK, and other components or enhancements.
+```bash
+make start
+```
 
-We've already made [huge
-progress](https://github.com/open-telemetry/opentelemetry-demo/blob/main/CHANGELOG.md),
-and development is ongoing. We hope to represent the full feature set of
-OpenTelemetry across its languages in the future.
+This will run docker compose to bring up all demo containers, including Feldera.
 
-If you'd like to help (**which we would love**), check out our [contributing
-guidance](./CONTRIBUTING.md).
+* Navigate to [localhost:28080](http://localhost:28080) to see the Feldera UI.
+  Select the `otel` pipeline (it will be the only pipeline in the list) and
+  click on the `Performance` tab to check that resource span records are streaming 
+  in from the collector.
 
-If you'd like to extend this demo or maintain a fork of it, read our
-[fork guidance](https://opentelemetry.io/docs/demo/forking/).
+* Switch to the `Ad hoc queries` tab and try querying materialized views:
+  ```sql
+  SELECT * FROM span_stat;
+  ```
 
-## Quick start
+## Architecture
 
-You can be up and running with the demo in a few minutes. Check out the docs for
-your preferred deployment method:
 
-- [Docker](https://opentelemetry.io/docs/demo/docker_deployment/)
-- [Kubernetes](https://opentelemetry.io/docs/demo/kubernetes_deployment/)
+```
+┌─────────────┐ otlp  ┌──────────────┐         ┌──────────┐
+│microservices├──────►│OTel Collector├────────►│ Feldera  │
+└─────────────┘       └──────────────┘         │(otel.sql)│
+                                               └──────────┘
+```
 
-## Documentation
+## Limitations and future work
 
-For detailed documentation, see [Demo Documentation][docs]. If you're curious
-about a specific feature, the [docs landing page][docs] can point you in the
-right direction.
+This demo is a proof of concept showing how Feldera can process complex
+semi-structured OpenTelemetry data in real-time.  It does not yet fully integrate
+Feldera in the OpenTelemetry ecosystem.
 
-## Demos featuring the Astronomy Shop
+* Feldera currently only ingests otlp messages in the uncompressed JSON format
+  over HTTP.  Going forward, we will add support for ProtoBuf and gzipped JSON formats.
 
-We welcome any vendor to fork the project to demonstrate their services and
-adding a link below. The community is committed to maintaining the project and
-keeping it up to date for you.
+* Feldera's HTTP input connector supports streaming inputs, while oltp is a
+  request/response-based protocol.  This mostly works fine, except that Feldera
+  does not correctly report HTTP input statistics (number of events received,
+  number of errors, etc)
 
-|                                         |                             |                                                                |
-|-----------------------------------------|-----------------------------|----------------------------------------------------------------|
-| [AlibabaCloud LogService][AlibabaCloud] | [Elastic][Elastic]          | [New Relic][NewRelic]                                          |
-| [AppDynamics][AppDynamics]              | [Google Cloud][GoogleCloud] | [OpenSearch][OpenSearch]                                       |
-| [Aspecto][Aspecto]                      | [Grafana Labs][GrafanaLabs] | [Sentry][Sentry]                                               |
-| [Axiom][Axiom]                          | [Guance][Guance]            | [ServiceNow Cloud Observability][ServiceNowCloudObservability] |
-| [Axoflow][Axoflow]                      | [Helios][Helios]            | [Splunk][Splunk]                                               |
-| [Azure Data Explorer][Azure]            | [Honeycomb.io][Honeycombio] | [Sumo Logic][SumoLogic]                                        |
-| [Coralogix][Coralogix]                  | [Instana][Instana]          | [TelemetryHub][TelemetryHub]                                   |
-| [Dash0][Dash0]                          | [Kloudfuse][Kloudfuse]      | [Teletrace][Teletrace]                                         |
-| [Datadog][Datadog]                      | [Liatrio][Liatrio]          | [Tracetest][Tracetest]                                         |
-| [Dynatrace][Dynatrace]                  | [Logz.io][Logzio]           | [Uptrace][Uptrace]                                             |
+* We do not yet support otlp output.
 
-## Contributing
-
-To get involved with the project see our [CONTRIBUTING](CONTRIBUTING.md)
-documentation. Our [SIG Calls](CONTRIBUTING.md#join-a-sig-call) are every other
-Monday at 8:30 AM PST and anyone is welcome.
-
-## Project leadership
-
-[Maintainers](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer)
-([@open-telemetry/demo-maintainers](https://github.com/orgs/open-telemetry/teams/demo-maintainers)):
-
-- [Juliano Costa](https://github.com/julianocosta89), Datadog
-- [Mikko Viitanen](https://github.com/mviitane), Dynatrace
-- [Pierre Tessier](https://github.com/puckpuck), Honeycomb
-
-[Approvers](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver)
-([@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers)):
-
-- [Cedric Ziel](https://github.com/cedricziel) Grafana Labs
-- [Penghan Wang](https://github.com/wph95), AppDynamics
-- [Reiley Yang](https://github.com/reyang), Microsoft
-- [Roger Coll](https://github.com/rogercoll), Elastic
-- [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
-
-Emeritus:
-
-- [Austin Parker](https://github.com/austinlparker)
-- [Carter Socha](https://github.com/cartersocha)
-- [Michael Maxwell](https://github.com/mic-max)
-- [Morgan McLean](https://github.com/mtwo)
-
-### Thanks to all the people who have contributed
-
-[![contributors](https://contributors-img.web.app/image?repo=open-telemetry/opentelemetry-demo)](https://github.com/open-telemetry/opentelemetry-demo/graphs/contributors)
-
-[docs]: https://opentelemetry.io/docs/demo/
-
-<!-- Links for Demos featuring the Astronomy Shop section -->
-
-[AlibabaCloud]: https://github.com/aliyun-sls/opentelemetry-demo
-[AppDynamics]: https://www.appdynamics.com/blog/cloud/how-to-observe-opentelemetry-demo-app-in-appdynamics-cloud/
-[Aspecto]: https://github.com/aspecto-io/opentelemetry-demo
-[Axiom]: https://play.axiom.co/axiom-play-qf1k/dashboards/otel.traces.otel-demo-traces
-[Axoflow]: https://axoflow.com/opentelemetry-support-in-more-detail-in-axosyslog-and-syslog-ng/
-[Azure]: https://github.com/Azure/Azure-kusto-opentelemetry-demo
-[Coralogix]: https://coralogix.com/blog/configure-otel-demo-send-telemetry-data-coralogix
-[Dash0]: https://github.com/dash0hq/opentelemetry-demo
-[Datadog]: https://docs.datadoghq.com/opentelemetry/guide/otel_demo_to_datadog
-[Dynatrace]: https://www.dynatrace.com/news/blog/opentelemetry-demo-application-with-dynatrace/
-[Elastic]: https://github.com/elastic/opentelemetry-demo
-[GoogleCloud]: https://github.com/GoogleCloudPlatform/opentelemetry-demo
-[GrafanaLabs]: https://github.com/grafana/opentelemetry-demo
-[Guance]: https://github.com/GuanceCloud/opentelemetry-demo
-[Helios]: https://otelsandbox.gethelios.dev
-[Honeycombio]: https://github.com/honeycombio/opentelemetry-demo
-[Instana]: https://github.com/instana/opentelemetry-demo
-[Kloudfuse]: https://github.com/kloudfuse/opentelemetry-demo
-[Liatrio]: https://github.com/liatrio/opentelemetry-demo
-[Logzio]: https://logz.io/learn/how-to-run-opentelemetry-demo-with-logz-io/
-[NewRelic]: https://github.com/newrelic/opentelemetry-demo
-[OpenSearch]: https://github.com/opensearch-project/opentelemetry-demo
-[Sentry]: https://github.com/getsentry/opentelemetry-demo
-[ServiceNowCloudObservability]: https://docs.lightstep.com/otel/quick-start-operator#send-data-from-the-opentelemetry-demo
-[Splunk]: https://github.com/signalfx/opentelemetry-demo
-[SumoLogic]: https://www.sumologic.com/blog/common-opentelemetry-demo-application/
-[TelemetryHub]: https://github.com/TelemetryHub/opentelemetry-demo/tree/telemetryhub-backend
-[Teletrace]: https://github.com/teletrace/opentelemetry-demo
-[Tracetest]: https://github.com/kubeshop/opentelemetry-demo
-[Uptrace]: https://github.com/uptrace/uptrace/tree/master/example/opentelemetry-demo
+* It should be straightforward to integrate Feldera as a processor in the OTel
+  Collector.   This requires building a go wrapper around the Feldera REST API.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,38 @@ networks:
     driver: bridge
 
 services:
+  feldera:
+    tty: true
+    image: ghcr.io/feldera/pipeline-manager:${FELDERA_VERSION:-0.28.0}
+    ports:
+      - "28080:8080"
+      - "28081:8081"
+    stop_grace_period: 0s
+    environment:
+      - RUST_LOG=info,actix_web=error,tokio_postgres=info
+      - RUST_BACKTRACE=1
+      - AUTH_CLIENT_ID
+      - AUTH_ISSUER
+    security_opt:
+      # The default seccomp profile disables the `io_uring_*` syscalls that we need.
+      # Ideally, we would minimally relax the default profile, which is usually in
+      # /usr/share/container/seccomp.json, but we often start via `curl` of just this
+      # `docker-compose.yml`, so there's no way to grab the specific file at the
+      # same time, so instead we just use `seccomp:unconfined`.
+      #
+      #- seccomp:seccomp.json
+      - seccomp:unconfined
+    healthcheck:
+      # TODO: add `/status` endpoint.
+      test:
+        [
+          "CMD-SHELL",
+          "curl --fail --request GET --url http://localhost:8080/healthz"
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   # ******************
   # Core Demo Services
   # ******************
@@ -393,13 +425,14 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 5G
     restart: unless-stopped
     ports:
       - "${LOCUST_WEB_PORT}"
     environment:
       - LOCUST_WEB_PORT
-      - LOCUST_USERS
+      - LOCUST_USERS=50
+      - LOCUST_SPAWN_RATE=10
       - LOCUST_HOST
       - LOCUST_HEADLESS
       - LOCUST_AUTOSTART

--- a/otel.sql
+++ b/otel.sql
@@ -1,0 +1,108 @@
+-- The following SQL type declarations match otlp protobuf schema for trace
+-- messages.
+
+CREATE TYPE KeyValue AS (
+    key VARCHAR,
+    value VARIANT
+);
+
+CREATE TYPE Event AS (
+    timeUnixNano VARCHAR,
+    name VARCHAR,
+    attributes KeyValue ARRAY
+);
+
+CREATE TYPE Span AS (
+    traceId VARCHAR,
+    spanId VARCHAR,
+    traceState VARCHAR,
+    parentSpanId VARCHAR,
+    flags BIGINT,
+    name VARCHAR,
+    kind INT,
+    startTimeUnixNano VARCHAR,
+    endTimeUnixNano VARCHAR,
+    attributes KeyValue ARRAY,
+    events Event ARRAY
+);
+
+CREATE TYPE ScopeSpans AS (
+    scope VARIANT,
+    spans Span ARRAY
+);
+
+CREATE TYPE Resource AS (
+    attributes KeyValue ARRAY
+);
+
+CREATE TYPE ResourceSpans AS (
+    resource Resource,
+    scopeSpans ScopeSpans ARRAY
+);
+
+-- Input table tahat ingests resource spans from the collector.
+CREATE TABLE otel_traces (
+    resourceSpans ResourceSpans ARRAY   
+) WITH ('append_only' = 'true');
+
+CREATE VIEW resource_spans AS
+SELECT
+    resourceSpans.*
+FROM
+    otel_traces, UNNEST(resourceSpans) as resourceSpans;
+
+-- Extract individual scope spans from resource spans.
+CREATE VIEW scope_spans AS 
+SELECT
+    scopeSpan.scope['name'] as scopeName,
+    scopeSpan.spans
+FROM
+    resource_spans, UNNEST(scopeSpans) AS scopeSpan;
+
+-- Extract individual spans, convert timestamps to integers.
+CREATE VIEW spans AS
+SELECT
+    scope_spans.scopeName as scopeName,
+    traceId,
+    spanId,
+    traceState,
+    parentSpanId,
+    flags,
+    name,
+    kind,
+    CAST(startTimeUnixNano AS BIGINT) AS startTimeUnixNano,
+    CAST(endTimeUnixNano AS BIGINT) AS endTimeUnixNano,
+    attributes,
+    events
+FROM
+    scope_spans, UNNEST(spans) as span;
+
+-- The following annotation tells Feldera that data in the `spans` view
+-- arrives at most 5 minutes (1 minute = 60^E+9 ns) out of order.
+LATENESS spans.endTimeUnixNano 60000000000;
+
+-- Compute global statistics for the entire stream.
+CREATE MATERIALIZED VIEW span_stat AS
+SELECT
+    scopeName,
+    COUNT(*) numSpans,
+    AVG(endTimeUnixNano - startTimeUnixNano) avgTime,
+    SUM(endTimeUnixNano - startTimeUnixNano) totalTime,
+    SUM(COALESCE(array_length(events), 0)) as numEvents
+FROM
+    spans
+GROUP BY scopeName;
+
+-- Compute statistics for each 1-minute window.
+CREATE MATERIALIZED VIEW span_stat_tumbling AS
+SELECT
+    (endTimeUnixNano / 60000000000) * 60000000000 AS window_end,
+    scopeName,
+    COUNT(*) numSpans,
+    AVG(endTimeUnixNano - startTimeUnixNano) avgTime,
+    SUM(endTimeUnixNano - startTimeUnixNano) totalTime,
+    SUM(COALESCE(array_length(events), 0)) as numEvents
+FROM
+    spans
+GROUP BY
+    scopeName, (endTimeUnixNano / 60000000000) * 60000000000;

--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -4,15 +4,18 @@
 # extra settings to be merged into OpenTelemetry Collector configuration
 # do not delete this file
 
-## Example configuration for sending data to your own OTLP HTTP backend
-## Note: the spanmetrics exporter must be included in the exporters array
-## if overriding the traces pipeline.
-##
-#  exporters:
-#    otlphttp/example:
-#      endpoint: <your-endpoint-url>
-#
-#  service:
-#    pipelines:
-#      traces:
-#        exporters: [spanmetrics, otlphttp/example]
+
+exporters:
+
+  # Send traces to the Feldera pipeline.
+  # Currently only uncompressed JSON is supported.
+  otlphttp/feldera_traces:
+     endpoint: http://feldera:8080/v0/pipelines/otel/ingress
+     traces_endpoint: http://feldera:8080/v0/pipelines/otel/ingress/otel_traces?format=json&update_format=raw
+     encoding: json
+     compression: none
+
+service:
+   pipelines:
+     traces:
+       exporters: [spanmetrics, otlphttp/feldera_traces]

--- a/start_feldera_pipeline.py
+++ b/start_feldera_pipeline.py
@@ -1,0 +1,12 @@
+# This script uses the Feldera API to create and start a pipeline using SQL
+# program in 'otel.sql'.
+
+from feldera import FelderaClient, PipelineBuilder
+
+sql = open("otel.sql").read()
+
+client = FelderaClient('http://localhost:28080')
+
+print('Starting pipeline')
+pipeline = PipelineBuilder(client, 'otel', sql).create_or_replace()
+pipeline.start()


### PR DESCRIPTION
The demo currently implements the following analysis:
* Parse OTel trace stream.
* Flatten ResourceSpans data into individual spans (in SQL).
* Global aggregation: compute totals and average runtimes per scope for the entire event history.
* Time-based aggregation: compute the same aggregates per 1-minute tumbling window.

Architecture
------------

```
┌─────────────┐ otlp  ┌──────────────┐         ┌──────────┐
│microservices├──────►│OTel Collector├────────►│ Feldera  │
└─────────────┘       └──────────────┘         │(otel.sql)│
                                               └──────────┘
```

See details in the README.